### PR TITLE
Fix select prompt issue

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TOOL_VERSION=v0.9.1
+TOOL_VERSION=v0.9.2
 DATABASE_VERSION="v0.9.1"
 GDRIVE_CLIENT_ID=""
 GDRIVE_CLIENT_SEC=""

--- a/pkg/inputs/inputs_prompt.go
+++ b/pkg/inputs/inputs_prompt.go
@@ -20,7 +20,6 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"regexp"
 	"strings"
 )
 
@@ -156,12 +155,11 @@ func PromptForSelect(l string, size int, items []PromptSelectInfo) (string, erro
 		Size:      size,
 		Templates: templates,
 	}
-	_, result, err := prompt.Run()
-	regex, err := regexp.Compile("{(.*) (.*)}")
+	index, _, err := prompt.Run()
 	if err != nil {
 		return "", err
 	}
-	return string(regex.FindAllSubmatch([]byte(result), -1)[0][1]), nil
+	return items[index].ID, nil
 }
 
 // HasProvidedValidID returns a function which validates the ID input.

--- a/test/scenario_test_file.sh
+++ b/test/scenario_test_file.sh
@@ -17,7 +17,7 @@
 set -e
 MASTER_PASSWORD="test1234"
 NEW_MASTER_PASSWORD="test12345"
-VERSION="v0.9.0"
+VERSION="v0.9.2"
 
 pushd ../
  make build-darwin TOOL_VERSION=${VERSION}
@@ -34,7 +34,7 @@ test -d ./password-manager-test && rm -rf ./password-manager-test
 test -f ./export-data.csv  && rm ./export-data.csv
 
 ../target/darwin/${VERSION}/password-manager init -m ${MASTER_PASSWORD}
-../target/darwin/${VERSION}/password-manager add test -u test.com -p test12345 -l "fb,gmail" -m ${MASTER_PASSWORD}
+../target/darwin/${VERSION}/password-manager add test -u test.com -p test12345 -l "fb,gmail" -d "Test description @maanadev" -m ${MASTER_PASSWORD}
 ../target/darwin/${VERSION}/password-manager get test -m ${MASTER_PASSWORD} -s | grep "test12345"
 echo "===Searching password==="
 ../target/darwin/${VERSION}/password-manager search test -s -m ${MASTER_PASSWORD} | grep "test12345"

--- a/test/scenario_test_gdrive.sh
+++ b/test/scenario_test_gdrive.sh
@@ -17,7 +17,7 @@
 set -e
 MASTER_PASSWORD="test1234"
 NEW_MASTER_PASSWORD="test12345"
-VERSION="v0.9.0"
+VERSION="v0.9.2"
 GDRIVE_CLIENT_ID=""
 GDRIVE_CLIENT_SEC=""
 
@@ -43,7 +43,7 @@ test -d ./password-manager-test && rm -rf ./password-manager-test
 test -f ./export-data.csv  && rm ./export-data.csv
 
 ../target/darwin/${VERSION}/password-manager init -m ${MASTER_PASSWORD}
-../target/darwin/${VERSION}/password-manager add test -u test.com -p test12345 -l "fb,gmail" -m ${MASTER_PASSWORD}
+../target/darwin/${VERSION}/password-manager add test -u test.com -p test12345 -l "fb,gmail" -d "Test description @maanadev" -m ${MASTER_PASSWORD}
 ../target/darwin/${VERSION}/password-manager get test -m ${MASTER_PASSWORD} -s | grep "test12345"
 echo "===Searching password==="
 ../target/darwin/${VERSION}/password-manager search test -s -m ${MASTER_PASSWORD} | grep "test12345"


### PR DESCRIPTION
In the current implementation, when the description contains spaces it unable to get the password entry.

Fixes #49 